### PR TITLE
commons-189-recommendations-not-working

### DIFF
--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -3,6 +3,8 @@
     exit; // Exit if accessed directly.
 }
 
+use ElasticPress\Command as ElasticPress_CLI_Command;
+
 /**
  * CLI Commands for ElasticPress BuddyPress
  *

--- a/elasticpress-rest.php
+++ b/elasticpress-rest.php
@@ -55,8 +55,7 @@ class EPR_REST_Posts_Controller extends WP_REST_Controller {
 
 		add_action( 'ep_add_query_log', function( $ep_query ) use ( &$response, &$debug ) {
 			$debug['ep_query'] = $ep_query;
-
-			//$response->set_status( $ep_query['request']['response']['code'] );
+			$response->set_status( $ep_query['request']['response']['code'] );
 		} );
 
 		$wp_query->query( array_merge(


### PR DESCRIPTION
This PR updates elasticpress-buddypress for compatibility with the current version of ElasticPress.

Most of the changes are adaptations to the updated namespacing and architecture of ElasticPress. The current version of ElasticPress now uses PHP namespaces, so to reference classes and functions within ElasticPress this plugin has to use those namespaces. Additionally, what were global functions in previous versions of ElasticPress are now class methods. For example, ```EP_API::factory()->prepare_meta_types``` becomes:

```
$indexables = ElasticPress\Indexables::factory()->get_all();
if ( empty( $indexables ) ) {
	return [];
}
return $indexables[0]->prepare_meta_types( $post_meta );
```

and ```ep_remote_request``` becomes ```ElasticPress\Elasticsearch::factory()->remote_request```.

The other significant change is that ElasticSearch, [as of version 6.0](https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html), does not allow multiple mapping types in a single index. This means that everything in the index now has to have a type of 'post' rather than 'post', 'user', 'humcore' and so on. This does not appear to affect search results.


